### PR TITLE
allow user defined ipaddress instead of only the default fact ipaddress

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Manages the server.
 **Default:** */opt/neo4j*
 - `allow_remote_connections` -- Whether to allow remote connections to Neo4j instead of only from localhost.
 **Default:** *true*
+- `address` -- Specify the address to listen at if `allow_remote_connections` is set to *true*.
+**Default:** *ipaddress* (from puppet facts)
 
 ######Custom Memory Attributes
 - `jvm_init_memory`\* -- Initial memory size of the jvm. Equates to java option "-Xms=XXX". Specified in MBs.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,7 +35,7 @@ class neo4j (
 
   #server options
   $allow_remote_connections = true,
-  $address = $ipaddress,
+  $address = $::ipaddress,
   $jvm_init_memory = '1024',
   $jvm_max_memory = '1024',
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,7 @@ class neo4j (
 
   #server options
   $allow_remote_connections = true,
+  $address = $ipaddress,
   $jvm_init_memory = '1024',
   $jvm_max_memory = '1024',
 

--- a/templates/neo4j-server.properties.erb
+++ b/templates/neo4j-server.properties.erb
@@ -14,7 +14,7 @@ org.neo4j.server.database.location=<%= @install_prefix -%>/data/graph.db
 # accept local connections). Uncomment to allow any connection. Please see the
 # security section in the neo4j manual before modifying this.
 <% if @allow_remote_connections -%>
-org.neo4j.server.webserver.address=<%= @ipaddress %>
+org.neo4j.server.webserver.address=<%= @address %>
 <% end -%>
 
 # http port (for all data, administrative, and UI access)


### PR DESCRIPTION
When allowing remote connections, the IP address is automatically be assigned using the puppet fact `ipaddress`. If wanting Neo4j to listen on all interfaces an IP address of 0.0.0.0 should be used which is not currently possible.

This pull request makes a minor change that enables a user to define the IP address as a parameter while defaulting to the puppet fact `ipaddress` if not specified. 

This fixes issue #12 