### PR TITLE
Allow http(s) ports and ssl configuration to be customised

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,18 @@ Manages the server.
 **Default:** *true*
 - `address` -- Specify the address to listen at if `allow_remote_connections` is set to *true*.
 **Default:** *ipaddress* (from puppet facts)
+- `http_port` -- Specify the http port to listen on
+**Default:** *7474*
+- `https_enabled` -- Enable Neo4j to listen for encrypted (https) connections
+**Defaukt:** *true*
+- `https_port` -- Specify the https port to listen on
+**Default:** *7473*
+-- `ssl_cert` -- Specify the ssl public certificate used with encrypted connections
+**Default:** *conf/ssl/snakeoil.cert*
+-- `ssl_key` -- Specify the ssl private key used with encrypted connections
+**Default:** *conf/ssl/snakeoil.key*
+-- `ssl_keystore` -- Specify SSL keystore used with encrypted connections
+**Default:** *undef*
 
 ######Custom Memory Attributes
 - `jvm_init_memory`\* -- Initial memory size of the jvm. Equates to java option "-Xms=XXX". Specified in MBs.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,12 @@ class neo4j (
   #server options
   $allow_remote_connections = true,
   $address = $::ipaddress,
+  $http_port = '7474',
+  $https_port = '7473',
+  $https_enabled = true,
+  $ssl_cert = 'conf/ssl/snakeoil.cert',
+  $ssl_key = 'conf/ssl/snakeoil.key',
+  $ssl_keystore = undef,
   $jvm_init_memory = '1024',
   $jvm_max_memory = '1024',
 

--- a/templates/neo4j-server.properties.erb
+++ b/templates/neo4j-server.properties.erb
@@ -18,13 +18,16 @@ org.neo4j.server.webserver.address=<%= @address %>
 <% end -%>
 
 # http port (for all data, administrative, and UI access)
-org.neo4j.server.webserver.port=7474
-org.neo4j.server.webserver.https.enabled=true
-org.neo4j.server.webserver.https.port=7473
-org.neo4j.server.webserver.https.cert.location=conf/ssl/snakeoil.cert
-org.neo4j.server.webserver.https.key.location=conf/ssl/snakeoil.key
-
+org.neo4j.server.webserver.port=<%= @http_port %>
+org.neo4j.server.webserver.https.enabled=<%= @https_enabled %>
+org.neo4j.server.webserver.https.port=<%= @https_port %>
+org.neo4j.server.webserver.https.cert.location=<%= @ssl_cert %>
+org.neo4j.server.webserver.https.key.location=<%= @ssl_key %>
+<% if @ssl_keystore -%>
+org.neo4j.server.webserver.https.keystore.location=<%= @ssl_keystore %>
+<% else -%>
 org.neo4j.server.webserver.https.keystore.location=<%= @install_prefix -%>/data/keystore
+<% end -%>
 
 #*****************************************************************
 # Administration client configuration


### PR DESCRIPTION
Minor tweaks to enable users to set additional properties for neo4j deployment (from updated README.md):
- `http_port` -- Specify the http port to listen on
  **Default:** _7474_
- `https_enabled` -- Enable Neo4j to listen for encrypted (https) connections
  **Defaukt:** _true_
- `https_port` -- Specify the https port to listen on
  **Default:** _7473_
  -- `ssl_cert` -- Specify the ssl public certificate used with encrypted connections
  **Default:** _conf/ssl/snakeoil.cert_
  -- `ssl_key` -- Specify the ssl private key used with encrypted connections
  **Default:** _conf/ssl/snakeoil.key_
  -- `ssl_keystore` -- Specify SSL keystore used with encrypted connections
  **Default:** _undef_

Would appreciate comments, I made the changes because of local infrastructure requirements and figured they might be useful to community.
$ssl_cert = 'conf/ssl/snakeoil.cert',
$ssl_key = 'conf/ssl/snakeoil.key',
$ssl_keystore = undef,
